### PR TITLE
order id uppercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,23 @@ app.get('/ico', (req, res) => {
   res.sendFile(path.resolve(ICO_ROOT, 'index.html'));
 });
 
-app.get('*', (req, res) => {
+// Handling lowercase order Ids
+var orderUppercase = (req, res, next) => {
+
+  if (req.params.orderId) {
+    const orderIdUP =  req.params.orderId.toUpperCase()
+    if (req.params.orderId != orderIdUP) {
+      res.redirect('/order/' + orderIdUP)
+    }
+    else {
+      next()
+    }
+  }
+};
+
+// General handler for the rest of the URLs
+var generalHandler = (req, res) => {
+
   let redirectRequired = false;
   let params = {};
   if (req.query.cur_from && req.query.cur_to) {
@@ -31,7 +47,6 @@ app.get('*', (req, res) => {
     req.query.lang =  req.query.lang.toLowerCase()
   }
 
-
   if (redirectRequired) {
       params = req.query;
       params = Object.keys(params).map(key => key + '=' + params[key]).join('&');
@@ -39,8 +54,14 @@ app.get('*', (req, res) => {
   }
 
   res.sendFile(path.resolve(process.env.NEXCHANGE_ROOT, 'index.html'));
+};
 
-});
+// Convert order ids to uppercase
+app.get('/order/:orderId', [orderUppercase, generalHandler]
+);
+
+// For all other cases
+app.get('*', generalHandler);
 
 app.listen(3000, () => console.log('Nexchange Frontend Proxy is listening on port 3000!'));
 


### PR DESCRIPTION
WAIT TO BE REVIEWED

1. Issue
Sometimes users use lowercase urls for orders, e.g.: https://n.exchange/sdfusdf7
But backend uses uppercase ids, so the order ids should be transformed.

2. Solution
Added a new routing function that handles the case when the order id is lower case and when it is ok
then let's the route continue to the normal operation.